### PR TITLE
[CI test] Verify cleanup-ci-w22712082 workflows trigger correctly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   android-base:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android
     strategy:
       fail-fast: false
@@ -24,6 +26,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   android-sfdx:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android sfdx
     strategy:
       fail-fast: false
@@ -38,6 +42,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   ios-base-legacy:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 18
     strategy:
       fail-fast: false
@@ -52,6 +58,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-base:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 26
     strategy:
       fail-fast: false
@@ -65,6 +73,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-sfdx:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS sfdx
     strategy:
       fail-fast: false
@@ -78,6 +88,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-upgrade:
+    permissions:
+      contents: read
     # Run upgrade tests after so standard login's don't revoke upgrade refresh
     # tokens mid-execution by hitting the user session limit.
     needs: [android-base, android-sfdx]
@@ -101,6 +113,8 @@ jobs:
       ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
 
   ios-upgrade:
+    permissions:
+      contents: read
     # If macos runner concurrency limit increases run these after standard login like Android.
     name: ${{ matrix.app }} iOS Upgrade from ${{ matrix.upgradeFrom }}
     strategy:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,6 +38,8 @@ jobs:
           fi
 
   ios-pr:
+    permissions:
+      contents: read
     needs: [permission-check]
     strategy:
       fail-fast: false
@@ -51,6 +53,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-pr:
+    permissions:
+      contents: read
     needs: [permission-check]
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target required for fork PRs to receive secrets.
   # Mitigated by permission-check job's Member Check pattern.
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [master]
+    branches: [master, cleanup-ci-w22712082]
 
 permissions:
   contents: read

--- a/.github/workflows/version-test.yaml
+++ b/.github/workflows/version-test.yaml
@@ -13,6 +13,8 @@ permissions:
 
 jobs:
   android:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android
     strategy:
       fail-fast: false
@@ -27,6 +29,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   ios-legacy:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 18
     strategy:
       fail-fast: false
@@ -43,6 +47,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 26
     strategy:
       fail-fast: false

--- a/iOS/Util/UITestConfig.swift
+++ b/iOS/Util/UITestConfig.swift
@@ -1,3 +1,4 @@
+// CI test trigger for W-22712082; revert before merge.
 /*
  * Copyright (c) 2026-present, salesforce.com, inc.
  * All rights reserved.


### PR DESCRIPTION
## Purpose

Test PR to exercise the new cleanup-ci-w22712082 workflow files before opening the upstream PR (W-22712082).

## What's in the diff

- .github/workflows/pr.yaml: temporarily extend branches: filter to include cleanup-ci-w22712082. Reverted before upstream PR.
- iOS/Util/UITestConfig.swift: trivial comment to drive the build pipeline. Reverted before upstream PR.

## Acceptance

CI must succeed on this PR. Once green, the upstream PR for the underlying cleanup-ci-w22712082 branch can be opened against forcedotcom:master (this repo's primary branch is master, not dev).

DO NOT MERGE — for CI verification only.